### PR TITLE
Put models into GitHub Actions cache

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
         ports:
           - 11434:11434
         volumes:
-          - ${{ github.workspace }}/.ollama/:/root/.ollama
+          - /home/runner/work/.ollama/:/root/.ollama
         options: >-
           --name ollama
           --health-cmd "ollama ps"
@@ -32,7 +32,7 @@ jobs:
         id: cache-models
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.ollama/models
+          path: /home/runner/work/.ollama/models
           key: models
 
       - name: Set up Python

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: root suid tar
+        run: sudo chown root /bin/tar && sudo chmod u+s /bin/tar
+
       - name: Cache Ollama Models
         id: cache-models
         uses: actions/cache@v4

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
         ports:
           - 11434:11434
         volumes:
-          - .ollama/:/root/.ollama
+          - ./.ollama/:/root/.ollama
         options: >-
           --name ollama
           --health-cmd "ollama ps"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,6 +15,8 @@ jobs:
         image: ollama/ollama:latest
         ports:
           - 11434:11434
+        volumes:
+          - .ollama/:/root/.ollama
         options: >-
           --name ollama
           --health-cmd "ollama ps"
@@ -25,6 +27,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Cache Ollama Models
+        id: cache-models
+        uses: actions/cache@v4
+        with:
+          path: .ollama/models
+          key: models
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
         ports:
           - 11434:11434
         volumes:
-          - ./.ollama/:/root/.ollama
+          - ${{ github.workspace }}/.ollama/:/root/.ollama
         options: >-
           --name ollama
           --health-cmd "ollama ps"
@@ -32,7 +32,7 @@ jobs:
         id: cache-models
         uses: actions/cache@v4
         with:
-          path: .ollama/models
+          path: ${{ github.workspace }}/.ollama/models
           key: models
 
       - name: Set up Python

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: root suid tar
+      - name: Allow cache to extract as root
         run: sudo chown root /bin/tar && sudo chmod u+s /bin/tar
 
       - name: Cache Ollama Models
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Cache ollama models between runs to save pulling from ollamahub every time CI runs.

Closes #4 