### PR TITLE
Make model configurable

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,10 @@ extensions = [
     "sphinx_llm.docref",
 ]
 
+sphinx_llm_options = {
+    "model": "llama3.2:3b",
+}
+
 templates_path = ['_templates']
 exclude_patterns = []
 

--- a/docs/source/test.rst
+++ b/docs/source/test.rst
@@ -3,5 +3,6 @@ Testing page
 
 
 .. docref:: apples
+   :model: llama3.2:3b
    
    Check out this awesome page on apples


### PR DESCRIPTION
Closes #3 

You can override the default model in `conf.py`.

```python
# conf.py
# ...
sphinx_llm_options = {
    "model": "llama3.2:3b",
}
```

Or you can do it on a per-directive basis.

```rst
.. docref:: apples
   :model: llama3.2:3b

   Check out this awesome page on apples
```