### PR TITLE
Test multiple sphinx major versions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build Sphinx documentation
         run: |
-          uv run --dev --extra gen --with sphinx=="${{ matrix.sphinx-version }}" sphinx-build -b html docs/source docs/build/html
+          uv run --dev --extra gen --with "sphinx${{ matrix.sphinx-version }}" sphinx-build -b html docs/source docs/build/html
 
       - name: DEBUG Output updated source file
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+        sphinx-version: ["5", "6", "7", "8"]
 
     services:
       ollama:
@@ -42,11 +46,11 @@ jobs:
         uses: astral-sh/setup-uv@v6.3.1
         with:
           version: "latest"
-          python-version: 3.12
+          python-version: ${{ matrix.python-version }}
 
       - name: Build Sphinx documentation
         run: |
-          uv run --dev --extra gen sphinx-build -b html docs/source docs/build/html
+          uv run --dev --extra gen --with sphinx==${{ matrix.sphinx-version }} sphinx-build -b html docs/source docs/build/html
 
       - name: DEBUG Output updated source file
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
-        sphinx-version: ["5", "6", "7", "8"]
+        sphinx-version: [">=5.1,<6", ">=6,<7", ">=7,<8", ">=8,<9"]
 
     services:
       ollama:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build Sphinx documentation
         run: |
-          uv run --dev --extra gen --with sphinx==${{ matrix.sphinx-version }} sphinx-build -b html docs/source docs/build/html
+          uv run --dev --extra gen --with sphinx=="${{ matrix.sphinx-version }}" sphinx-build -b html docs/source docs/build/html
 
       - name: DEBUG Output updated source file
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: uv run --dev --extra gen --with sphinx==${{ matrix.sphinx-version }} pytest src/sphinx_llm/tests/ --cov=sphinx_llm --cov-report=xml
+        run: uv run --dev --extra gen --with sphinx=="${{ matrix.sphinx-version }}" pytest src/sphinx_llm/tests/ --cov=sphinx_llm --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,13 @@ jobs:
             sphinx-version: "8"
           # Test each Python version against latest Sphinx
           - python-version: "3.9"
-            sphinx-version: "8"
+            sphinx-version: "7"
           - python-version: "3.10"
-            sphinx-version: "8"
+            sphinx-version: "7"
           - python-version: "3.11"
-            sphinx-version: "8"
+            sphinx-version: "7"
           - python-version: "3.12"
-            sphinx-version: "8"
+            sphinx-version: "7"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        include:
+          # Test each Sphinx version against latest Python
+          - python-version: "3.12"
+            sphinx-version: "5"
+          - python-version: "3.12"
+            sphinx-version: "6"
+          - python-version: "3.12"
+            sphinx-version: "7"
+          - python-version: "3.12"
+            sphinx-version: "8"
+          # Test each Python version against latest Sphinx
+          - python-version: "3.9"
+            sphinx-version: "8"
+          - python-version: "3.10"
+            sphinx-version: "8"
+          - python-version: "3.11"
+            sphinx-version: "8"
+          - python-version: "3.12"
+            sphinx-version: "8"
 
     steps:
       - name: Checkout repository
@@ -24,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: uv run --dev --extra gen pytest src/sphinx_llm/tests/ --cov=sphinx_llm --cov-report=xml
+        run: uv run --dev --extra gen --with sphinx==${{ matrix.sphinx-version }} pytest src/sphinx_llm/tests/ --cov=sphinx_llm --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,22 +14,22 @@ jobs:
         include:
           # Test each Sphinx version against latest Python
           - python-version: "3.12"
-            sphinx-version: "5"
+            sphinx-version: ">=5.1,<6"
           - python-version: "3.12"
-            sphinx-version: "6"
+            sphinx-version: ">=6,<7"
           - python-version: "3.12"
-            sphinx-version: "7"
+            sphinx-version: ">=7,<8"
           - python-version: "3.12"
-            sphinx-version: "8"
+            sphinx-version: ">=8,<9"
           # Test each Python version against latest Sphinx
           - python-version: "3.9"
-            sphinx-version: "7"
+            sphinx-version: ">=7,<8"
           - python-version: "3.10"
-            sphinx-version: "7"
+            sphinx-version: ">=7,<8"
           - python-version: "3.11"
-            sphinx-version: "7"
+            sphinx-version: ">=7,<8"
           - python-version: "3.12"
-            sphinx-version: "7"
+            sphinx-version: ">=7,<8"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: uv run --dev --extra gen --with sphinx=="${{ matrix.sphinx-version }}" pytest src/sphinx_llm/tests/ --cov=sphinx_llm --cov-report=xml
+        run: uv run --dev --extra gen --with "sphinx${{ matrix.sphinx-version }}" pytest src/sphinx_llm/tests/ --cov=sphinx_llm --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "sphinx-markdown-builder>=0.6.8",
-    "sphinx>=7.4.7",
+    "sphinx>=5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Currently we specify that we need `sphinx>=7` in `pyproject.toml`. But in theory we could support older Sphinx versions too.

The `sphinx-markdown-builder` dependency that we rely on for `llms.txt` supports `sphinx>=5.1`.

Playing around in a PR to see how things work against various Sphinx versions.